### PR TITLE
fix generate encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM ruby:2.4.1
 
-ENV LC_ALL C.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
-
 RUN mkdir /app
 WORKDIR /app
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ namespace :guides do
     desc "Generate HTML guides"
     task html: :encoding do
       ENV["WARNINGS"] = "1" # authors can't disable this
-      ruby "rails_guides.rb"
+      ruby "-E UTF-8 rails_guides.rb"
     end
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"


### PR DESCRIPTION
官方的 encoding 设置在 docker 里还是有问题，再加上 -E UTF-8 设定编码。